### PR TITLE
chore: release docs for transformation utilities and bump 0.1.7

### DIFF
--- a/docs/api/utils_transformations.md
+++ b/docs/api/utils_transformations.md
@@ -1,0 +1,11 @@
+# Transformation Utilities
+
+::: spark_fuse.utils.transformations
+    handler: python
+    options:
+      members:
+        - rename_columns
+        - with_constants
+        - cast_columns
+        - normalize_whitespace
+        - split_by_date_formats

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,14 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 
 ## [Unreleased]
 
+## [0.1.7] - 2025-09-06
+### Added
+- Transformation utilities module offering column renaming, casting, literal injection, whitespace cleanup, and multi-format date parsing helpers.
+- Test coverage for the transformation utilities, including `split_by_date_formats` error modes.
+
+### Documentation
+- Added API reference page for transformation utilities and highlighted the new helpers in the feature overview.
+
 ## [0.1.6] - 2025-09-05
 ### Changed
 - Rename module `spark_fuse.utils.scd2` to `spark_fuse.utils.scd` (update imports accordingly).
@@ -68,7 +76,8 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - Tests: registry resolution, path validation (ADLS/Fabric), and SQL generation (UC/Hive).
 - CI: Python 3.9–3.11 matrix, ruff + pytest. Pre-commit hooks and Makefile.
 
-[Unreleased]: https://github.com/kevinsames/spark-fuse/compare/v0.1.6...HEAD
+[Unreleased]: https://github.com/kevinsames/spark-fuse/compare/v0.1.7...HEAD
+[0.1.7]: https://github.com/kevinsames/spark-fuse/compare/v0.1.6...v0.1.7
 [0.1.6]: https://github.com/kevinsames/spark-fuse/compare/v0.1.5...v0.1.6
 [0.1.5]: https://github.com/kevinsames/spark-fuse/compare/v0.1.4...v0.1.5
 [0.1.4]: https://github.com/kevinsames/spark-fuse/compare/v0.1.3...v0.1.4

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,6 +6,7 @@ spark-fuse is an open-source toolkit for PySpark — providing utilities, connec
 - Connectors for ADLS Gen2 (`abfss://`), Fabric OneLake (`onelake://` or `abfss://...onelake.dfs.fabric.microsoft.com/...`), and Databricks DBFS (`dbfs:/`).
 - Unity Catalog and Hive Metastore helpers to create catalogs/schemas and register external Delta tables.
 - SparkSession helpers with sensible defaults and environment detection (Databricks/Fabric/local).
+- DataFrame utilities for previews, name management, casts, whitespace cleanup, and resilient date parsing.
 - Typer-powered CLI: list connectors, preview datasets, register tables, submit Databricks jobs.
 
 ## Quickstart

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -64,3 +64,4 @@ nav:
       - Utils — DataFrame: api/utils_dataframe.md
       - Utils — Logging: api/utils_logging.md
       - Utils — SCD: api/utils_scd.md
+      - Utils — Transformations: api/utils_transformations.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "spark-fuse"
-version = "0.1.6"
+version = "0.1.7"
 description = "Open-source PySpark toolkit with connectors and CLI for Azure Storage, Databricks, Microsoft Fabric Lakehouses, Unity Catalog, and Hive Metastore."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/spark_fuse/utils/transformations.py
+++ b/src/spark_fuse/utils/transformations.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from typing import Any, Iterable, Mapping, Union
+
+from pyspark.sql import DataFrame, functions as F
+from pyspark.sql.types import DataType
+
+__all__ = [
+    "rename_columns",
+    "with_constants",
+    "cast_columns",
+    "normalize_whitespace",
+]
+
+
+def rename_columns(df: DataFrame, mapping: Mapping[str, str]) -> DataFrame:
+    """Rename columns according to ``mapping`` while preserving column order.
+
+    Raises:
+        ValueError: If any source column is missing or the resulting columns collide.
+    """
+    if not mapping:
+        return df
+
+    missing = [name for name in mapping if name not in df.columns]
+    if missing:
+        raise ValueError(f"Cannot rename missing columns: {missing}")
+
+    final_names = [mapping.get(name, name) for name in df.columns]
+    if len(final_names) != len(set(final_names)):
+        raise ValueError("Renaming results in duplicate column names")
+
+    renamed = []
+    for name in df.columns:
+        new_name = mapping.get(name, name)
+        column = F.col(name)
+        if new_name != name:
+            column = column.alias(new_name)
+        renamed.append(column)
+    return df.select(*renamed)
+
+
+def with_constants(
+    df: DataFrame,
+    constants: Mapping[str, Any],
+    *,
+    overwrite: bool = False,
+) -> DataFrame:
+    """Add literal-valued columns using ``constants``.
+
+    Args:
+        constants: Mapping of column name to literal value.
+        overwrite: Replace existing columns when ``True`` (default ``False``).
+
+    Raises:
+        ValueError: If attempting to add an existing column without ``overwrite``.
+    """
+    if not constants:
+        return df
+
+    if not overwrite:
+        duplicates = [name for name in constants if name in df.columns]
+        if duplicates:
+            raise ValueError(f"Columns already exist: {duplicates}")
+
+    result = df
+    for name, value in constants.items():
+        result = result.withColumn(name, F.lit(value))
+    return result
+
+
+TypeMapping = Mapping[str, Union[str, DataType]]
+
+
+def cast_columns(df: DataFrame, type_mapping: TypeMapping) -> DataFrame:
+    """Cast columns to new Spark SQL types.
+
+    The ``type_mapping`` values may be ``str`` or ``DataType`` instances.
+
+    Raises:
+        ValueError: If any referenced column is missing.
+    """
+    if not type_mapping:
+        return df
+
+    missing = [name for name in type_mapping if name not in df.columns]
+    if missing:
+        raise ValueError(f"Cannot cast missing columns: {missing}")
+
+    coerced = []
+    for name in df.columns:
+        if name in type_mapping:
+            coerced.append(F.col(name).cast(type_mapping[name]).alias(name))
+        else:
+            coerced.append(F.col(name))
+    return df.select(*coerced)
+
+
+_DEFAULT_REGEX = r"\s+"
+
+
+def normalize_whitespace(
+    df: DataFrame,
+    columns: Iterable[str],
+    *,
+    trim_ends: bool = True,
+    pattern: str = _DEFAULT_REGEX,
+    replacement: str = " ",
+) -> DataFrame:
+    """Collapse repeated whitespace in string columns.
+
+    Args:
+        columns: Iterable of column names to normalize. Duplicates are ignored.
+        trim_ends: When ``True``, also ``trim`` the resulting string.
+        pattern: Regex pattern to match; defaults to consecutive whitespace.
+        replacement: Replacement string for the regex matches.
+
+    Raises:
+        TypeError: If ``columns`` is provided as a single ``str``.
+        ValueError: If any referenced column is missing.
+    """
+    if isinstance(columns, str):
+        raise TypeError("columns must be an iterable of column names, not a string")
+
+    targets = list(dict.fromkeys(columns))
+    if not targets:
+        return df
+
+    missing = [name for name in targets if name not in df.columns]
+    if missing:
+        raise ValueError(f"Cannot normalize missing columns: {missing}")
+
+    result = df
+    for name in targets:
+        normalized = F.regexp_replace(F.col(name), pattern, replacement)
+        if trim_ends:
+            normalized = F.trim(normalized)
+        result = result.withColumn(name, normalized)
+    return result

--- a/src/spark_fuse/utils/transformations.py
+++ b/src/spark_fuse/utils/transformations.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Iterable, Mapping, Union
+from typing import Any, Iterable, Mapping, Optional, Tuple, Union
 
 from pyspark.sql import DataFrame, functions as F
 from pyspark.sql.types import DataType
@@ -10,6 +10,7 @@ __all__ = [
     "with_constants",
     "cast_columns",
     "normalize_whitespace",
+    "split_by_date_formats",
 ]
 
 
@@ -136,4 +137,112 @@ def normalize_whitespace(
         if trim_ends:
             normalized = F.trim(normalized)
         result = result.withColumn(name, normalized)
+    return result
+
+
+_HANDLE_ERROR_MODES = {"null", "strict", "default"}
+
+
+def split_by_date_formats(
+    df: DataFrame,
+    column: str,
+    formats: Iterable[str],
+    *,
+    handle_errors: str = "null",
+    default_value: Optional[str] = None,
+    return_unmatched: bool = False,
+    output_column: Optional[str] = None,
+) -> Union[DataFrame, Tuple[DataFrame, DataFrame]]:
+    """Split ``df`` into per-format partitions with safely parsed date columns.
+
+    Args:
+        column: Name of the string column containing date representations.
+        formats: Iterable of date format strings, evaluated in order.
+        handle_errors: Strategy for unmatched rows (``"null"``, ``"strict"``, ``"default"``).
+        default_value: Fallback date string when ``handle_errors="default"``.
+        return_unmatched: When ``True``, also return the unmatched rows DataFrame.
+        output_column: Optional name for the parsed date column; defaults to ``f"{column}_date"``.
+
+    Returns:
+        The combined DataFrame containing all parsed rows.
+
+        When ``return_unmatched`` is ``True``, also returns the unmatched rows
+        DataFrame as a second element.
+
+    Raises:
+        TypeError: If ``formats`` is a string or contains non-string entries.
+        ValueError: For missing columns, duplicate output column, invalid modes, or
+            unmatched rows when in ``strict`` mode.
+    """
+
+    if column not in df.columns:
+        raise ValueError(f"Column '{column}' not found in DataFrame")
+
+    parsed_column = output_column or f"{column}_date"
+    if parsed_column in df.columns and parsed_column != column:
+        raise ValueError(f"Output column '{parsed_column}' already exists")
+
+    if isinstance(formats, str):
+        raise TypeError("formats must be an iterable of strings, not a string")
+
+    format_list = list(dict.fromkeys(formats))
+    if not format_list:
+        raise ValueError("At least one date format must be provided")
+
+    if any(not isinstance(fmt, str) for fmt in format_list):
+        raise TypeError("Each format must be a string")
+
+    mode = handle_errors.lower()
+    if mode not in _HANDLE_ERROR_MODES:
+        raise ValueError(f"Unsupported handle_errors mode '{handle_errors}'")
+
+    if mode == "default" and default_value is None:
+        raise ValueError("default_value must be provided when handle_errors='default'")
+
+    parsed_expressions = [F.to_date(F.col(column), fmt) for fmt in format_list]
+    if len(parsed_expressions) == 1:
+        parsed_expr = parsed_expressions[0]
+    else:
+        parsed_expr = F.coalesce(*parsed_expressions)
+
+    format_idx_expr = None
+    for idx, expr in enumerate(parsed_expressions):
+        candidate = F.when(expr.isNotNull(), F.lit(idx))
+        format_idx_expr = (
+            candidate if format_idx_expr is None else format_idx_expr.otherwise(candidate)
+        )
+    if format_idx_expr is None:
+        format_idx_expr = F.lit(None)
+
+    format_idx_column = f"__{column}_format_idx__"
+    while format_idx_column in df.columns:
+        format_idx_column = f"_{format_idx_column}"
+
+    df_with_meta = df.withColumn(parsed_column, parsed_expr).withColumn(
+        format_idx_column, format_idx_expr
+    )
+
+    partitions: list[DataFrame] = []
+    for idx, _ in enumerate(format_list):
+        group_df = df_with_meta.filter(F.col(format_idx_column) == idx).drop(format_idx_column)
+        partitions.append(group_df)
+
+    unmatched_df = df_with_meta.filter(F.col(format_idx_column).isNull()).drop(format_idx_column)
+
+    if mode == "strict":
+        if unmatched_df.limit(1).collect():
+            raise ValueError("Unmatched rows detected while handle_errors='strict'")
+    elif mode == "default":
+        default_df = unmatched_df.withColumn(parsed_column, F.lit(default_value).cast("date"))
+        partitions.append(default_df)
+    else:
+        partitions.append(unmatched_df)
+
+    result_df = partitions[0]
+    for part in partitions[1:]:
+        result_df = result_df.unionByName(part)
+
+    result: Union[DataFrame, Tuple[DataFrame, DataFrame]] = result_df
+    if return_unmatched:
+        result = (result_df, unmatched_df)
     return result

--- a/tests/utils/test_transformations.py
+++ b/tests/utils/test_transformations.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from spark_fuse.utils.transformations import (
+    cast_columns,
+    normalize_whitespace,
+    rename_columns,
+    split_by_date_formats,
+    with_constants,
+)
+
+
+def _rows_by_id(df, id_col="id"):
+    return {row[id_col]: row.asDict(recursive=True) for row in df.collect()}
+
+
+def test_rename_columns_success(spark):
+    df = spark.createDataFrame([{"name": "Alice", "value": 1}])
+
+    result = rename_columns(df, {"name": "full_name"})
+
+    assert result.columns == ["full_name", "value"]
+    rows = _rows_by_id(result, "value")
+    assert rows[1]["full_name"] == "Alice"
+
+
+def test_rename_columns_missing_raises(spark):
+    df = spark.createDataFrame([{"name": "Alice"}])
+
+    with pytest.raises(ValueError, match="Cannot rename missing"):
+        rename_columns(df, {"missing": "other"})
+
+
+def test_with_constants_add_and_overwrite(spark):
+    df = spark.createDataFrame([{"id": 1, "country": "US"}])
+
+    result = with_constants(df, {"source": "ingest"})
+    rows = _rows_by_id(result)
+    assert rows[1]["source"] == "ingest"
+
+    overwritten = with_constants(df, {"country": "CA"}, overwrite=True)
+    rows_overwrite = _rows_by_id(overwritten)
+    assert rows_overwrite[1]["country"] == "CA"
+
+
+def test_with_constants_existing_column_without_overwrite_raises(spark):
+    df = spark.createDataFrame([{"id": 1}])
+
+    with pytest.raises(ValueError, match="Columns already exist"):
+        with_constants(df, {"id": 10})
+
+
+def test_cast_columns_types(spark):
+    df = spark.createDataFrame([{"id": "1", "flag": "true"}])
+
+    result = cast_columns(df, {"id": "int", "flag": "boolean"})
+    row = result.collect()[0]
+    assert row["id"] == 1
+    assert row["flag"] is True
+
+
+def test_cast_columns_missing_source_raises(spark):
+    df = spark.createDataFrame([{"id": "1"}])
+
+    with pytest.raises(ValueError, match="Cannot cast missing"):
+        cast_columns(df, {"missing": "int"})
+
+
+def test_normalize_whitespace_basic(spark):
+    df = spark.createDataFrame([{"id": 1, "text": "  hello   world  "}])
+
+    result = normalize_whitespace(df, ["text"])
+    rows = _rows_by_id(result)
+    assert rows[1]["text"] == "hello world"
+
+
+def test_normalize_whitespace_no_trim(spark):
+    df = spark.createDataFrame([{"id": 1, "text": "foo\tbar"}])
+
+    result = normalize_whitespace(df, ["text"], trim_ends=False, replacement="_")
+    rows = _rows_by_id(result)
+    assert rows[1]["text"] == "foo_bar"
+
+
+def test_normalize_whitespace_requires_iterable(spark):
+    df = spark.createDataFrame([{"id": 1, "text": " value "}])
+
+    with pytest.raises(TypeError):
+        normalize_whitespace(df, "text")
+
+
+def test_split_by_date_formats_null_mode_with_unmatched(spark):
+    df = spark.createDataFrame(
+        [
+            {"id": 1, "raw": "2023-01-01"},
+            {"id": 2, "raw": "01/15/2023"},
+            {"id": 3, "raw": "bad"},
+        ]
+    )
+
+    result_df, unmatched_df = split_by_date_formats(
+        df,
+        "raw",
+        ["yyyy-MM-dd", "MM/dd/yyyy"],
+        return_unmatched=True,
+    )
+
+    rows = _rows_by_id(result_df)
+    assert rows[1]["raw_date"] == date(2023, 1, 1)
+    assert rows[2]["raw_date"] == date(2023, 1, 15)
+    assert rows[3]["raw_date"] is None
+
+    unmatched_rows = _rows_by_id(unmatched_df)
+    assert set(unmatched_rows) == {3}
+    assert unmatched_rows[3]["raw_date"] is None
+
+
+def test_split_by_date_formats_default_mode_sets_fallback(spark):
+    df = spark.createDataFrame(
+        [
+            {"id": 1, "raw": "2023-01-01"},
+            {"id": 2, "raw": "bad"},
+        ]
+    )
+
+    result_df, unmatched_df = split_by_date_formats(
+        df,
+        "raw",
+        ["yyyy-MM-dd"],
+        handle_errors="default",
+        default_value="2000-01-01",
+        return_unmatched=True,
+    )
+
+    rows = _rows_by_id(result_df)
+    assert rows[1]["raw_date"] == date(2023, 1, 1)
+    assert rows[2]["raw_date"] == date(2000, 1, 1)
+
+    unmatched_rows = _rows_by_id(unmatched_df)
+    assert unmatched_rows[2]["raw_date"] is None
+
+
+def test_split_by_date_formats_strict_mode_raises_on_unmatched(spark):
+    df = spark.createDataFrame(
+        [
+            {"id": 1, "raw": "2023-01-01"},
+            {"id": 2, "raw": "bad"},
+        ]
+    )
+
+    with pytest.raises(ValueError, match="handle_errors='strict'"):
+        split_by_date_formats(df, "raw", ["yyyy-MM-dd"], handle_errors="strict")


### PR DESCRIPTION
## Summary

Added new Transformations Library.

## Changes

Documented the new transformation helpers across the docs site so they surface in the features list, API reference, and navigation (docs/index.md:5, docs/api/utils_transformations.md:1, mkdocs.yml:56).
Logged a 0.1.7 changelog entry capturing the transformations module, accompanying tests, and documentation updates (docs/changelog.md:9).
Bumped the project version to 0.1.7 for the release (pyproject.toml:7).

## Type of change

- [x] feat (new feature)
- [ ] fix (bug fix)
- [ ] docs (documentation only)
- [ ] chore (maint, build, deps)
- [ ] refactor (no functional change)
- [ ] perf (performance)
- [ ] test (add or refactor tests)
- [ ] ci (workflow changes)

## How was this tested?

- [x] Unit tests
- [ ] Manual / local validation
- [ ] Other (describe)

## Checklist

- [x] Lint passes (`ruff check`)
- [x] Tests pass (`pytest`)
- [x] Docs updated (README / MkDocs / CLI help)
- [x] Changelog updated (if user-facing change)

## Related issues

Closes #
