### PR TITLE
`scd2_upsert` partitions each batch by business key and load order so…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 ## [Unreleased]
 - _No changes yet._
 
+## [1.0.1] - 2025-11-18
+### Added
+- Unit coverage for `scd2_upsert` scenarios where multiple changes for a key arrive in the same
+  batch, plus a corresponding example in the demo notebook to visualize the full history.
+
+### Changed
+- `scd2_upsert` now sequences duplicate business keys within a batch so each intermediate state is
+  written with its own version rather than only keeping the latest row from the source feed.
+
+### Documentation
+- Noted the intra-batch sequencing behavior in the SCD documentation/demo so teams know that the
+  helper preserves every version even when the upstream dataset is not pre-collapsed.
+
 ## [1.0.0] - 2025-11-16
 ### Changed
 - Require PySpark 4.x (and delta-spark 4.x) in the Python package metadata and auto-detect the Scala
@@ -103,7 +116,8 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - Tests: registry resolution, path validation (ADLS/Fabric), and SQL generation (UC/Hive).
 - CI: Python 3.9–3.11 matrix, ruff + pytest. Pre-commit hooks and Makefile.
 
-[Unreleased]: https://github.com/kevinsames/spark-fuse/compare/v1.0.0...HEAD
+[Unreleased]: https://github.com/kevinsames/spark-fuse/compare/v1.0.1...HEAD
+[1.0.1]: https://github.com/kevinsames/spark-fuse/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/kevinsames/spark-fuse/compare/v0.3.2...v1.0.0
 [0.3.2]: https://github.com/kevinsames/spark-fuse/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/kevinsames/spark-fuse/compare/v0.3.0...v0.3.1

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,19 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 ## [Unreleased]
 - _No changes yet._
 
+## [1.0.1] - 2025-11-18
+### Added
+- Extended test coverage for `scd2_upsert` batches containing multiple updates per key and a demo
+  notebook example that highlights the resulting historical versions.
+
+### Changed
+- `scd2_upsert` sequences duplicate business keys within a single batch to ensure every change is
+  recorded with an incremented version rather than collapsing to the most recent row.
+
+### Documentation
+- Documented the intra-batch sequencing behavior in the SCD guide and notebook so teams understand
+  how history is preserved even when upstream data is not pre-deduplicated.
+
 ## [1.0.0] - 2025-11-16
 ### Changed
 - Require PySpark 4.x (and delta-spark 4.x) in the Python package metadata and auto-detect the Scala
@@ -158,7 +171,8 @@ The format is based on Keep a Changelog, and this project adheres to Semantic Ve
 - Tests: registry resolution, path validation (ADLS/Fabric), and SQL generation (UC/Hive).
 - CI: Python 3.9–3.11 matrix, ruff + pytest. Pre-commit hooks and Makefile.
 
-[Unreleased]: https://github.com/kevinsames/spark-fuse/compare/v1.0.0...HEAD
+[Unreleased]: https://github.com/kevinsames/spark-fuse/compare/v1.0.1...HEAD
+[1.0.1]: https://github.com/kevinsames/spark-fuse/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/kevinsames/spark-fuse/compare/v0.4.0...v1.0.0
 [0.4.0]: https://github.com/kevinsames/spark-fuse/compare/v0.3.2...v0.4.0
 [0.3.2]: https://github.com/kevinsames/spark-fuse/compare/v0.3.0...v0.3.2

--- a/docs/releases/v1.0.1.md
+++ b/docs/releases/v1.0.1.md
@@ -1,0 +1,24 @@
+# Release v1.0.1 (2025-11-18)
+
+## Highlights
+- `scd2_upsert` now replays duplicate keys within a single batch in chronological order so every
+  change is stored as its own historical row.
+- The SCD demo notebook includes a "multiple updates per batch" walk-through to visualize the new
+  sequencing behavior directly in Delta Lake output.
+
+## Upgrade Notes
+- No action is required for existing pipelines. The helper automatically sequences inputs that have
+  not been pre-deduplicated and will continue to behave as before when one row per key is provided.
+
+## Detailed Changes
+### Added
+- Regression tests that feed multiple rows for a single key through `scd2_upsert` to validate that
+  every version is created.
+
+### Changed
+- `scd2_upsert` partitions each batch by business key and load order so earlier versions are closed
+  before inserting later ones, retaining complete history at write time.
+
+### Documentation
+- Noted the new intra-batch sequencing behavior in the SCD guide and notebook, including a dedicated
+  example that shows the resulting timeline of versions.

--- a/docs/scd_upsert_demo.md
+++ b/docs/scd_upsert_demo.md
@@ -44,7 +44,7 @@ scd1_upsert(
 
 ## SCD Type 2
 
-SCD2 tracks history by closing current rows (setting expiry timestamp, `is_current=false`) and inserting new versions.
+SCD2 tracks history by closing current rows (setting expiry timestamp, `is_current=false`) and inserting new versions. When a batch contains multiple records for the same business key, the helper processes them in chronological order so every change within the batch is preserved.
 
 ```python
 target_path = "/tmp/scd2_demo"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,6 +56,7 @@ nav:
       - Security: security.md
       - Governance: governance.md
       - Changelog: changelog.md
+      - Release v1.0.1: releases/v1.0.1.md
       - Release v1.0.0: releases/v1.0.0.md
       - Maintainers: maintainers.md
       - Authors: authors.md

--- a/notebooks/demos/scd_demo.ipynb
+++ b/notebooks/demos/scd_demo.ipynb
@@ -18,10 +18,78 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "spark-session",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING: Using incubator modules: jdk.incubator.vector\n",
+      ":: loading settings :: url = jar:file:/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages/pyspark/jars/ivy-2.5.3.jar!/org/apache/ivy/core/settings/ivysettings.xml\n",
+      "Ivy Default Cache set to: /Users/kevin/.ivy2.5.2/cache\n",
+      "The jars for the packages stored in: /Users/kevin/.ivy2.5.2/jars\n",
+      "io.delta#delta-spark_2.13 added as a dependency\n",
+      ":: resolving dependencies :: org.apache.spark#spark-submit-parent-1cee8401-1655-4b9a-9068-edeac2aab143;1.0\n",
+      "\tconfs: [default]\n",
+      "\tfound io.delta#delta-spark_2.13;4.0.0 in central\n",
+      "\tfound io.delta#delta-storage;4.0.0 in central\n",
+      "\tfound org.antlr#antlr4-runtime;4.13.1 in central\n",
+      ":: resolution report :: resolve 148ms :: artifacts dl 18ms\n",
+      "\t:: modules in use:\n",
+      "\tio.delta#delta-spark_2.13;4.0.0 from central in [default]\n",
+      "\tio.delta#delta-storage;4.0.0 from central in [default]\n",
+      "\torg.antlr#antlr4-runtime;4.13.1 from central in [default]\n",
+      "\t---------------------------------------------------------------------\n",
+      "\t|                  |            modules            ||   artifacts   |\n",
+      "\t|       conf       | number| search|dwnlded|evicted|| number|dwnlded|\n",
+      "\t---------------------------------------------------------------------\n",
+      "\t|      default     |   3   |   0   |   0   |   0   ||   3   |   0   |\n",
+      "\t---------------------------------------------------------------------\n",
+      ":: retrieving :: org.apache.spark#spark-submit-parent-1cee8401-1655-4b9a-9068-edeac2aab143\n",
+      "\tconfs: [default]\n",
+      "\t0 artifacts copied, 3 already retrieved (0kB/15ms)\n",
+      "25/11/18 11:25:31 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable\n",
+      "Using Spark's default log4j profile: org/apache/spark/log4j2-defaults.properties\n",
+      "Setting default log level to \"WARN\".\n",
+      "To adjust logging level use sc.setLogLevel(newLevel). For SparkR, use setLogLevel(newLevel).\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "            <div>\n",
+       "                <p><b>SparkSession - in-memory</b></p>\n",
+       "                \n",
+       "        <div>\n",
+       "            <p><b>SparkContext</b></p>\n",
+       "\n",
+       "            <p><a href=\"None\">Spark UI</a></p>\n",
+       "\n",
+       "            <dl>\n",
+       "              <dt>Version</dt>\n",
+       "                <dd><code>v4.0.1</code></dd>\n",
+       "              <dt>Master</dt>\n",
+       "                <dd><code>local[2]</code></dd>\n",
+       "              <dt>AppName</dt>\n",
+       "                <dd><code>spark-fuse-scd-demo</code></dd>\n",
+       "            </dl>\n",
+       "        </div>\n",
+       "        \n",
+       "            </div>\n",
+       "        "
+      ],
+      "text/plain": [
+       "<pyspark.sql.session.SparkSession at 0x10e81e7e0>"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "from pyspark.sql import Row\n",
     "from spark_fuse.spark import create_session\n",
@@ -49,10 +117,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "scd1-upsert",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "25/11/18 11:25:39 WARN SparkStringUtils: Truncated the string representation of a plan since it was too large. This behavior can be adjusted by setting 'spark.sql.debug.maxToStringFields'.\n",
+      "25/11/18 11:25:43 WARN MapPartitionsRDD: RDD 55 was locally checkpointed, its lineage has been truncated and cannot be recomputed after unpersisting\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+---+---+---+--------------------+\n",
+      "| id|val| ts|            row_hash|\n",
+      "+---+---+---+--------------------+\n",
+      "|  1|  c|  3|2e7d2c03a9507ae26...|\n",
+      "|  2|  x|  5|2d711642b726b0440...|\n",
+      "|  3|  z|  1|594e519ae499312b2...|\n",
+      "+---+---+---+--------------------+\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "from pyspark.sql import functions as F\n",
     "\n",
@@ -93,10 +184,35 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "scd2-upsert",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "25/11/18 11:25:46 WARN MapPartitionsRDD: RDD 172 was locally checkpointed, its lineage has been truncated and cannot be recomputed after unpersisting\n",
+      "25/11/18 11:25:49 WARN MapPartitionsRDD: RDD 284 was locally checkpointed, its lineage has been truncated and cannot be recomputed after unpersisting\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+---+---+---+--------------------+-------------------+-------------------+----------+-------+\n",
+      "| id|val| ts|            row_hash| effective_start_ts|   effective_end_ts|is_current|version|\n",
+      "+---+---+---+--------------------+-------------------+-------------------+----------+-------+\n",
+      "|  1|  a|  1|ca978112ca1bbdcaf...|2024-01-01 00:00:00|2024-01-01 00:00:00|     false|      1|\n",
+      "|  1|  b|  2|3e23e8160039594a3...|2024-01-01 00:00:00|2024-01-02 00:00:00|     false|      2|\n",
+      "|  1|  c|  3|2e7d2c03a9507ae26...|2024-01-02 00:00:00|               NULL|      true|      3|\n",
+      "|  2|  x|  5|2d711642b726b0440...|2024-01-01 00:00:00|               NULL|      true|      1|\n",
+      "|  3|  z|  1|594e519ae499312b2...|2024-01-02 00:00:00|               NULL|      true|      1|\n",
+      "+---+---+---+--------------------+-------------------+-------------------+----------+-------+\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "scd2_target_path = \"/tmp/scd2_demo\"\n",
     "\n",
@@ -131,6 +247,67 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Multiple updates per batch\n",
+    "\n",
+    "When several changes for the same business key arrive in a single feed, `scd2_upsert` processes them in chronological order so every intermediate version is preserved.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "25/11/18 11:25:53 WARN MapPartitionsRDD: RDD 430 was locally checkpointed, its lineage has been truncated and cannot be recomputed after unpersisting\n",
+      "25/11/18 11:25:55 WARN MapPartitionsRDD: RDD 515 was locally checkpointed, its lineage has been truncated and cannot be recomputed after unpersisting\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+---+------+---+--------------------+-------------------+-------------------+----------+-------+\n",
+      "| id|   val| ts|            row_hash| effective_start_ts|   effective_end_ts|is_current|version|\n",
+      "+---+------+---+--------------------+-------------------+-------------------+----------+-------+\n",
+      "| 10|bronze|  1|fcbbcd5a59bf48a18...|2024-01-03 00:00:00|2024-01-03 00:00:00|     false|      1|\n",
+      "| 10|silver|  2|78cde64c3e47f2cbf...|2024-01-03 00:00:00|2024-01-03 00:00:00|     false|      2|\n",
+      "| 10|  gold|  3|24d7f03d8dc3c3666...|2024-01-03 00:00:00|               NULL|      true|      3|\n",
+      "+---+------+---+--------------------+-------------------+-------------------+----------+-------+\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "multi_batch_target = \"/tmp/scd2_multi_batch\"\n",
+    "\n",
+    "multi_batch = spark.createDataFrame(\n",
+    "    [\n",
+    "        Row(id=10, val=\"bronze\", ts=1),\n",
+    "        Row(id=10, val=\"silver\", ts=2),\n",
+    "        Row(id=10, val=\"gold\", ts=3),\n",
+    "    ]\n",
+    ")\n",
+    "\n",
+    "scd2_upsert(\n",
+    "    spark,\n",
+    "    multi_batch,\n",
+    "    multi_batch_target,\n",
+    "    business_keys=[\"id\"],\n",
+    "    tracked_columns=[\"val\"],\n",
+    "    order_by=[\"ts\"],\n",
+    "    load_ts_expr=\"to_timestamp('2024-01-03 00:00:00')\",\n",
+    ")\n",
+    "\n",
+    "spark.read.format(\"delta\").load(multi_batch_target).orderBy(\"version\").show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "dispatcher-title",
    "metadata": {},
    "source": [
@@ -139,10 +316,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "dispatcher",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+---+---+--------------------+--------------------+----------------+----------+-------+\n",
+      "| id|val|            row_hash|  effective_start_ts|effective_end_ts|is_current|version|\n",
+      "+---+---+--------------------+--------------------+----------------+----------+-------+\n",
+      "|  1|  a|ca978112ca1bbdcaf...|2025-11-18 11:25:...|            NULL|      true|      1|\n",
+      "|  2|  b|3e23e8160039594a3...|2025-11-18 11:25:...|            NULL|      true|      1|\n",
+      "+---+---+--------------------+--------------------+----------------+----------+-------+\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "dispatcher_target = \"/tmp/apply_scd_demo\"\n",
     "apply_scd(\n",
@@ -159,7 +350,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "stop-spark",
    "metadata": {},
    "outputs": [],
@@ -170,13 +361,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": ".venv (3.12.3)",
    "language": "python",
    "name": "python3"
   },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "pygments_lexer": "ipython3"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
   }
  },
  "nbformat": 4,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "spark-fuse"
-version = "1.0.0"
+version = "1.0.1"
 description = "Open-source PySpark toolkit with connectors and CLI for Azure Storage, Databricks, Microsoft Fabric Lakehouses, REST APIs, and SPARQL endpoints."
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
… earlier versions are closed

  before inserting later ones, retaining complete history at write time.

## Summary

Describe the change and why it’s needed.

## Changes

-
-

## Type of change

- [ ] feat (new feature)
- [ ] fix (bug fix)
- [ ] docs (documentation only)
- [ ] chore (maint, build, deps)
- [ ] refactor (no functional change)
- [ ] perf (performance)
- [ ] test (add or refactor tests)
- [ ] ci (workflow changes)

## How was this tested?

- [ ] Unit tests
- [ ] Manual / local validation
- [ ] Other (describe)

## Checklist

- [ ] Lint passes (`ruff check`)
- [ ] Tests pass (`pytest`)
- [ ] Docs updated (README / MkDocs / CLI help)
- [ ] Changelog updated (if user-facing change)

## Related issues

Closes #
