### PR TITLE
Pinned CI to the actual PySpark distribution and export matching Delt…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    env:
-      SPARK_FUSE_DELTA_SCALA_SUFFIX: "2.13"
     strategy:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
@@ -29,6 +27,44 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e ".[dev]"
+      - name: Pin Spark runtime for tests
+        run: |
+          python - <<'PY'
+          import os
+          import pathlib
+          import re
+          import pyspark
+
+          spark_home = pathlib.Path(pyspark.__file__).resolve().parent
+          jars_dir = spark_home / "jars"
+          scala_suffix = None
+          spark_version = None
+
+          for jar in sorted(jars_dir.glob("spark-core_*.jar")):
+              match = re.search(r"spark-core_(\\d+\\.\\d+)-(\\d+\\.\\d+(?:\\.\\d+)?)\\.jar", jar.name)
+              if match:
+                  scala_suffix = match.group(1)
+                  spark_version = match.group(2)
+                  break
+
+          if not scala_suffix:
+              scala_suffix = "2.13"
+          if not spark_version:
+              spark_version = pyspark.__version__
+
+          major_minor = ".".join(spark_version.split(".")[:2])
+          delta_map = {"3.3": "2.3.0", "3.4": "2.4.0", "3.5": "3.2.0", "4.0": "4.0.0"}
+          delta_version = delta_map.get(major_minor, "4.0.0")
+
+          with open(os.environ["GITHUB_ENV"], "a") as handle:
+              handle.write(f"SPARK_HOME={spark_home}\\n")
+              handle.write(f"SPARK_FUSE_DELTA_SCALA_SUFFIX={scala_suffix}\\n")
+              handle.write(f"SPARK_FUSE_DELTA_VERSION={delta_version}\\n")
+
+          print(f"SPARK_HOME={spark_home}")
+          print(f"SPARK_FUSE_DELTA_SCALA_SUFFIX={scala_suffix}")
+          print(f"SPARK_FUSE_DELTA_VERSION={delta_version}")
+          PY
       - name: Lint
         run: |
           ruff --version


### PR DESCRIPTION
…a coordinates so the Spark/Scala/Delta trio stays consistent and avoids the LogKey NoSuchMethodError.

In ci.yml I removed the static SPARK_FUSE_DELTA_SCALA_SUFFIX and added a “Pin Spark runtime for tests” step that reads the spark-core_*.jar name from the installed PySpark package, then writes SPARK_HOME, SPARK_FUSE_DELTA_SCALA_SUFFIX, and SPARK_FUSE_DELTA_VERSION into GITHUB_ENV. That ensures the tests run against the Spark build you installed in the job, even if the runner has a different Spark in the environment.

## Summary

Describe the change and why it’s needed.

## Changes

-
-

## Type of change

- [ ] feat (new feature)
- [ ] fix (bug fix)
- [ ] docs (documentation only)
- [ ] chore (maint, build, deps)
- [ ] refactor (no functional change)
- [ ] perf (performance)
- [ ] test (add or refactor tests)
- [ ] ci (workflow changes)

## How was this tested?

- [ ] Unit tests
- [ ] Manual / local validation
- [ ] Other (describe)

## Checklist

- [ ] Lint passes (`ruff check`)
- [ ] Tests pass (`pytest`)
- [ ] Docs updated (README / MkDocs / CLI help)
- [ ] Changelog updated (if user-facing change)

## Related issues

Closes #
