### PR TITLE
Adjusted the CI env export to avoid the multiline SPARK_HOME parsing …

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,7 @@ jobs:
           pip install -e ".[dev]"
       - name: Pin Spark runtime for tests
         run: |
-          python - <<'PY'
-          import os
+          python - <<'PY' | tee -a "$GITHUB_ENV"
           import pathlib
           import re
           import pyspark
@@ -55,11 +54,6 @@ jobs:
           major_minor = ".".join(spark_version.split(".")[:2])
           delta_map = {"3.3": "2.3.0", "3.4": "2.4.0", "3.5": "3.2.0", "4.0": "4.0.0"}
           delta_version = delta_map.get(major_minor, "4.0.0")
-
-          with open(os.environ["GITHUB_ENV"], "a") as handle:
-              handle.write(f"SPARK_HOME={spark_home}\\n")
-              handle.write(f"SPARK_FUSE_DELTA_SCALA_SUFFIX={scala_suffix}\\n")
-              handle.write(f"SPARK_FUSE_DELTA_VERSION={delta_version}\\n")
 
           print(f"SPARK_HOME={spark_home}")
           print(f"SPARK_FUSE_DELTA_SCALA_SUFFIX={scala_suffix}")


### PR DESCRIPTION
…issue seen in the runner error. In ci.yml, the “Pin Spark runtime for tests” step now pipes the computed Spark env lines into GITHUB_ENV via tee instead of writing from inside Python, so each var is set cleanly.

Tests: pytest --maxfail=1 --disable-warnings -q failed locally with PySparkRuntimeError: JAVA_GATEWAY_EXITED because Spark can’t write the Ivy cache (/Users/kevin/.ivy2.5.2/cache) in this sandbox.

## Summary

Describe the change and why it’s needed.

## Changes

-
-

## Type of change

- [ ] feat (new feature)
- [ ] fix (bug fix)
- [ ] docs (documentation only)
- [ ] chore (maint, build, deps)
- [ ] refactor (no functional change)
- [ ] perf (performance)
- [ ] test (add or refactor tests)
- [ ] ci (workflow changes)

## How was this tested?

- [ ] Unit tests
- [ ] Manual / local validation
- [ ] Other (describe)

## Checklist

- [ ] Lint passes (`ruff check`)
- [ ] Tests pass (`pytest`)
- [ ] Docs updated (README / MkDocs / CLI help)
- [ ] Changelog updated (if user-facing change)

## Related issues

Closes #
