### PR TITLE
Fix multi-batch re-processing creating duplicates in track_history_up…

### DIFF
--- a/src/spark_fuse/utils/change_tracking.py
+++ b/src/spark_fuse/utils/change_tracking.py
@@ -368,6 +368,21 @@ def _track_history_process_batch(
     target_cols = set(target_dt.toDF().columns)
 
     if hash_col in target_cols:
+        # Idempotency guard: skip source rows whose (business_key, hash) already exists
+        # in the target (any version). This prevents re-processing the same changes_df
+        # from expiring current rows that were updated by later batches in a prior run.
+        existing_hashes = _read_target_df(spark, target).select(
+            *[F.col(k) for k in business_keys], F.col(hash_col)
+        )
+        source_batch = source_batch.join(
+            existing_hashes,
+            on=list(business_keys) + [hash_col],
+            how="left_anti",
+        )
+        if source_batch.limit(1).count() == 0:
+            _LOGGER.info("Batch skipped — all row hashes already present in target")
+            return True
+
         change_cond_sql = f"NOT (t.`{hash_col}` <=> s.`{hash_col}`)"
     else:
         change_cond_sql = (
@@ -405,10 +420,8 @@ def _track_history_process_batch(
     if insert_count == 0:
         return True
 
-    tgt_max_ver = (
-        tgt_after_merge
-        .groupBy(*business_keys)
-        .agg(F.max(F.col(version_col)).alias("__prev_version"))
+    tgt_max_ver = tgt_after_merge.groupBy(*business_keys).agg(
+        F.max(F.col(version_col)).alias("__prev_version")
     )
 
     rows_with_prev = rows_to_insert.join(tgt_max_ver, on=list(business_keys), how="left")

--- a/tests/utils/test_change_tracking.py
+++ b/tests/utils/test_change_tracking.py
@@ -396,7 +396,12 @@ def test_track_history_three_cycles_no_duplicates(spark, tmp_path: Path):
 
     # Cycle 2: update with changed data
     df2 = spark.createDataFrame([{"id": 1, "val": "b", "ts": 2}])
-    track_history_upsert(spark, df2, target, **{**common_kwargs, "load_ts_expr": "to_timestamp('2020-01-02 00:00:00')"})
+    track_history_upsert(
+        spark,
+        df2,
+        target,
+        **{**common_kwargs, "load_ts_expr": "to_timestamp('2020-01-02 00:00:00')"},
+    )
     out2 = spark.read.format("delta").load(target)
     assert out2.count() == 2, f"Expected 2 rows after first update, got {out2.count()}"
     assert out2.filter("is_current = true").count() == 1
@@ -406,13 +411,61 @@ def test_track_history_three_cycles_no_duplicates(spark, tmp_path: Path):
 
     # Cycle 3: same data as cycle 2 — must be a no-op
     df3 = spark.createDataFrame([{"id": 1, "val": "b", "ts": 3}])
-    track_history_upsert(spark, df3, target, **{**common_kwargs, "load_ts_expr": "to_timestamp('2020-01-03 00:00:00')"})
+    track_history_upsert(
+        spark,
+        df3,
+        target,
+        **{**common_kwargs, "load_ts_expr": "to_timestamp('2020-01-03 00:00:00')"},
+    )
     out3 = spark.read.format("delta").load(target)
     assert out3.count() == 2, f"Expected 2 rows after idempotent call, got {out3.count()}"
     assert out3.filter("is_current = true").count() == 1
     current3 = _rows_by_key(out3.filter("is_current = true"), "id")
     assert current3[1]["val"] == "b"
     assert current3[1]["version"] == 2
+
+
+def test_track_history_multi_batch_reprocessing_idempotent(spark, tmp_path: Path):
+    """Re-processing a multi-version changes_df (max_seq >= 2) must be a no-op.
+
+    Reproduces the bug where batch 1 (old data) incorrectly expires current rows
+    whose hashes differ because they were updated by batch 2 in the first run.
+    """
+    target = str(tmp_path / "multi_batch_idempotent")
+    common_kwargs = dict(
+        business_keys=["id"],
+        tracked_columns=["val"],
+        order_by=["ts"],
+        load_ts_expr="to_timestamp('2020-01-01 00:00:00')",
+    )
+
+    # changes_df has 2 versions per key (simulating CDC with old + new in same batch)
+    changes = spark.createDataFrame(
+        [
+            {"id": 1, "val": "a", "ts": 1},  # older version
+            {"id": 1, "val": "b", "ts": 2},  # newer version
+            {"id": 2, "val": "x", "ts": 1},  # older version
+            {"id": 2, "val": "y", "ts": 2},  # newer version
+        ]
+    )
+
+    # First run: should create 2 historical rows + 2 current rows = 4 rows total
+    track_history_upsert(spark, changes, target, **common_kwargs)
+    out1 = spark.read.format("delta").load(target)
+    assert out1.count() == 4, f"Expected 4 rows after first run, got {out1.count()}"
+    assert out1.filter("is_current = true").count() == 2
+    current1 = _rows_by_key(out1.filter("is_current = true"), "id")
+    assert current1[1]["val"] == "b"
+    assert current1[2]["val"] == "y"
+
+    # Second run: same data — must be a complete no-op
+    track_history_upsert(spark, changes, target, **common_kwargs)
+    out2 = spark.read.format("delta").load(target)
+    assert out2.count() == 4, f"Duplicates on re-processing: 4 -> {out2.count()}"
+    assert out2.filter("is_current = true").count() == 2
+    current2 = _rows_by_key(out2.filter("is_current = true"), "id")
+    assert current2[1]["val"] == "b"
+    assert current2[2]["val"] == "y"
 
 
 def test_track_history_three_cycles_with_changes(spark, tmp_path: Path):
@@ -427,15 +480,21 @@ def test_track_history_three_cycles_with_changes(spark, tmp_path: Path):
 
     # Cycle 1: bootstrap
     df1 = spark.createDataFrame([{"id": 1, "val": "a", "ts": 1}])
-    track_history_upsert(spark, df1, target, load_ts_expr="to_timestamp('2020-01-01')", **common_kwargs)
+    track_history_upsert(
+        spark, df1, target, load_ts_expr="to_timestamp('2020-01-01')", **common_kwargs
+    )
 
     # Cycle 2: change
     df2 = spark.createDataFrame([{"id": 1, "val": "b", "ts": 2}])
-    track_history_upsert(spark, df2, target, load_ts_expr="to_timestamp('2020-01-02')", **common_kwargs)
+    track_history_upsert(
+        spark, df2, target, load_ts_expr="to_timestamp('2020-01-02')", **common_kwargs
+    )
 
     # Cycle 3: another change
     df3 = spark.createDataFrame([{"id": 1, "val": "c", "ts": 3}])
-    track_history_upsert(spark, df3, target, load_ts_expr="to_timestamp('2020-01-03')", **common_kwargs)
+    track_history_upsert(
+        spark, df3, target, load_ts_expr="to_timestamp('2020-01-03')", **common_kwargs
+    )
 
     out = spark.read.format("delta").load(target)
     assert out.count() == 3, f"Expected 3 total rows, got {out.count()}"


### PR DESCRIPTION
…sert

When changes_df contains multiple versions per business key (max_seq >= 2), re-processing the same DataFrame would incorrectly expire current rows whose hashes differed from the older batch data, producing duplicate historical rows and end_ts < start_ts violations.

Fix: pre-filter each source batch in _track_history_process_batch to exclude rows whose (business_key, row_hash) already exists in the target. If the filtered batch is empty the merge is skipped entirely, making multi-batch re-processing idempotent.

Adds test_track_history_multi_batch_reprocessing_idempotent covering the exact scenario (max_seq=2, two keys, re-run must be a no-op).

## Summary

Describe the change and why it’s needed.

## Changes

-
-

## Type of change

- [ ] feat (new feature)
- [ ] fix (bug fix)
- [ ] docs (documentation only)
- [ ] chore (maint, build, deps)
- [ ] refactor (no functional change)
- [ ] perf (performance)
- [ ] test (add or refactor tests)
- [ ] ci (workflow changes)

## How was this tested?

- [ ] Unit tests
- [ ] Manual / local validation
- [ ] Other (describe)

## Checklist

- [ ] Lint passes (`ruff check`)
- [ ] Tests pass (`pytest`)
- [ ] Docs updated (README / MkDocs / CLI help)
- [ ] Changelog updated (if user-facing change)

## Related issues

Closes #
